### PR TITLE
Save previous map elements on resize

### DIFF
--- a/map.c
+++ b/map.c
@@ -101,8 +101,21 @@ map_resize(map_t *m, int new_cap)
     if (!nm) {
         return -1;
     }
-    memcpy(m, nm, sizeof(map_t));
-    map_free(nm);
+
+    for (int i = 0; i < m->len; i++) {
+        struct node *list = m->list[i];
+        struct node *temp = list;
+        while (temp) {
+            int st = map_set(nm, temp->key, temp->val);
+            if (st != 0) {
+                return -1;
+            }
+            temp = temp->next;
+        }
+    }
+
+    list_free(*m->list);
+    *m = *nm;
     return 0;
 }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -148,8 +148,16 @@ test_map_resize(void)
     map_set(m, "14", "1");
     map_set(m, "15", "1");
     map_set(m, "16", "1");
-    map_set(m, "17", "1");
+    map_set(m, "17", "111");
+    map_set(m, "18", "1");
     TEST_ASSERT_EQUAL_INT(32, m->cap);
+    TEST_ASSERT_EQUAL_INT(18, m->len);
+    for (int i = 1; i <= 18; i++) {
+        char key[2];
+	sprintf(key, "%d", i);
+        char *val = (char *)map_get(m, key);
+	TEST_ASSERT_NOT_NULL(val)
+    }
     map_free(m);
 }
 


### PR DESCRIPTION
Map losing list elements on resize.
This PR fixes it with setting elements from old map to new map.